### PR TITLE
Update Semaphore to v3

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,8 +12,7 @@
 	branch = v4.8.0
 [submodule "lib/semaphore"]
 	path = lib/semaphore
-	url = https://github.com/semaphore-protocol/semaphore
-	branch = d001dd9
+	url = https://github.com/worldcoin/semaphore-v3
 [submodule "lib/openzeppelin-contracts-upgradeable"]
 	path = lib/openzeppelin-contracts-upgradeable
 	url = https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable

--- a/script/deploy/DeployOpWorldID.s.sol
+++ b/script/deploy/DeployOpWorldID.s.sol
@@ -18,11 +18,12 @@ contract DeployOpWorldID is Script {
     OpWorldID public opWorldID;
 
     function run() external {
+        uint8 treeDepth = uint8(vm.envUint("TREE_DEPTH"));
         uint256 opWorldIDKey = vm.envUint("OP_WORLDID_PRIVATE_KEY");
 
         vm.startBroadcast(opWorldIDKey);
 
-        opWorldID = new OpWorldID(preRoot, preRootTimestamp);
+        opWorldID = new OpWorldID(treeDepth, preRoot, preRootTimestamp);
 
         vm.stopBroadcast();
     }

--- a/script/deploy/DeployPolygonWorldID.s.sol
+++ b/script/deploy/DeployPolygonWorldID.s.sol
@@ -27,11 +27,13 @@ contract DeployPolygonWorldID is Script {
     // address fxChildAddress = address(0x8397259c983751DAf40400790063935a11afa28a);
 
     function run() external {
+        uint8 treeDepth = uint8(vm.envUint("TREE_DEPTH"));
         uint256 PolygonWorldIDKey = vm.envUint("POLYGON_WORLDID_PRIVATE_KEY");
 
         vm.startBroadcast(PolygonWorldIDKey);
 
-        polygonWorldId = new PolygonWorldID(fxChildAddress, preRoot, preRootTimestamp, stateBridgeAddress);
+
+        polygonWorldId = new PolygonWorldID(treeDepth, fxChildAddress, preRoot, preRootTimestamp, stateBridgeAddress);
 
         vm.stopBroadcast();
     }

--- a/src/OpWorldID.sol
+++ b/src/OpWorldID.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.15;
 
-import {Verifier as SemaphoreVerifier} from "semaphore/contracts/base/Verifier.sol";
+import {SemaphoreVerifier} from "semaphore/packages/contracts/contracts/base/SemaphoreVerifier.sol";
 import {CrossDomainOwnable3} from "@eth-optimism/contracts-bedrock/contracts/L2/CrossDomainOwnable3.sol";
 
 /// @title OpWorldID
@@ -9,6 +9,9 @@ import {CrossDomainOwnable3} from "@eth-optimism/contracts-bedrock/contracts/L2/
 /// @notice A contract that manages the root history of the Semaphore identity merkle tree on Optimism.
 /// @dev This contract is deployed on Optimism and is called by the L1 Proxy contract for new root insertions.
 contract OpWorldID is CrossDomainOwnable3 {
+    /// @notice MarkleTree depth
+    uint8 internal treeDepth;
+
     /// @notice The amount of time a root is considered as valid on Optimism.
     uint256 internal constant ROOT_HISTORY_EXPIRY = 1 weeks;
 
@@ -31,8 +34,9 @@ contract OpWorldID is CrossDomainOwnable3 {
     /// @notice Initializes the contract with a pre-existing root and timestamp.
     /// @param preRoot The root of the merkle tree before the contract was deployed.
     /// @param preRootTimestamp The timestamp at which the pre-existing root was submitted.
-    constructor(uint256 preRoot, uint128 preRootTimestamp) {
+    constructor(uint8 _treeDepth, uint256 preRoot, uint128 preRootTimestamp) {
         rootHistory[preRoot] = preRootTimestamp;
+        treeDepth = _treeDepth;
     }
 
     /// @notice receiveRoot is called by the state bridge contract which forwards new WorldID roots to Optimism.
@@ -81,11 +85,9 @@ contract OpWorldID is CrossDomainOwnable3 {
         uint256 externalNullifierHash,
         uint256[8] calldata proof
     ) public view {
-        uint256[4] memory publicSignals = [root, nullifierHash, signalHash, externalNullifierHash];
-
         if (checkValidRoot(root)) {
             semaphoreVerifier.verifyProof(
-                [proof[0], proof[1]], [[proof[2], proof[3]], [proof[4], proof[5]]], [proof[6], proof[7]], publicSignals
+                root, nullifierHash, signalHash, externalNullifierHash, proof, treeDepth
             );
         }
     }

--- a/src/OpWorldID.sol
+++ b/src/OpWorldID.sol
@@ -101,4 +101,16 @@ contract OpWorldID is CrossDomainOwnable3 {
             );
         }
     }
+
+    /// @notice Gets the Semaphore tree depth the contract was initialized with.
+    ///
+    /// @return initializedTreeDepth Tree depth.
+    function getTreeDepth()
+        public
+        view
+        virtual
+        returns (uint8 initializedTreeDepth)
+    {
+        return treeDepth;
+    }
 }

--- a/src/PolygonWorldID.sol
+++ b/src/PolygonWorldID.sol
@@ -143,4 +143,16 @@ contract PolygonWorldID is FxBaseChildTunnel {
 
         receiveRoot(data);
     }
+
+    /// @notice Gets the Semaphore tree depth the contract was initialized with.
+    ///
+    /// @return initializedTreeDepth Tree depth.
+    function getTreeDepth()
+        public
+        view
+        virtual
+        returns (uint8 initializedTreeDepth)
+    {
+        return treeDepth;
+    }
 }

--- a/src/utils/SemaphoreTreeDepthValidator.sol
+++ b/src/utils/SemaphoreTreeDepthValidator.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.15;
+
+/// @title Semaphore tree depth validator
+/// @author Worldcoin
+library SemaphoreTreeDepthValidator {
+    /// @notice Checks if the provided `treeDepth` is amoung supported depths.
+    ///
+    /// @param treeDepth The tree depth to validate.
+    /// @return supportedDepth Returns `true` if `treeDepth` is between 16 and 32 - depths supported by the Semaphore
+    function validate(uint8 treeDepth) internal pure returns (bool supportedDepth)
+    {
+        uint8 minDepth = 16;
+        uint8 maxDepth = 32;
+        return treeDepth >= minDepth && treeDepth <= maxDepth;
+    }
+}

--- a/test/OpWorldID.t.sol
+++ b/test/OpWorldID.t.sol
@@ -24,6 +24,9 @@ contract OpWorldIDTest is Messenger_Initializer {
     /// @notice The OpWorldID contract
     OpWorldID internal id;
 
+    /// @notice MarkleTree depth
+    uint8 internal treeDepth = 16;
+
     /// @notice The root of the merkle tree before the first update
     uint256 public preRoot = 0x18f43331537ee2af2e3d758d50f72106467c6eea50371dd528d57eb2b856d238;
 
@@ -45,7 +48,7 @@ contract OpWorldIDTest is Messenger_Initializer {
 
         /// @notice Initialize the OpWorldID contract
         vm.prank(alice);
-        id = new OpWorldID(preRoot, preRootTimestamp);
+        id = new OpWorldID(treeDepth, preRoot, preRootTimestamp);
 
         /// @dev label important addresses
         vm.label(address(this), "Sender");

--- a/test/OpWorldID.t.sol
+++ b/test/OpWorldID.t.sol
@@ -5,6 +5,7 @@ pragma solidity >=0.8.15;
 // import { PRBTest } from "@prb/test/PRBTest.sol";
 // import { StdCheats } from "forge-std/StdCheats.sol";
 import {OpWorldID} from "../src/OpWorldID.sol";
+import {SemaphoreTreeDepthValidator} from "../src/utils/SemaphoreTreeDepthValidator.sol";
 import {L2CrossDomainMessenger} from "@eth-optimism/contracts-bedrock/contracts/L2/L2CrossDomainMessenger.sol";
 import {Predeploys} from "@eth-optimism/contracts-bedrock/contracts/libraries/Predeploys.sol";
 import {CommonTest, Messenger_Initializer} from "@eth-optimism/contracts-bedrock/contracts/test/CommonTest.t.sol";
@@ -38,6 +39,15 @@ contract OpWorldIDTest is Messenger_Initializer {
 
     /// @notice CrossDomainOwnable3.sol transferOwnership event
     event OwnershipTransferred(address indexed previousOwner, address indexed newOwner, bool isLocal);
+
+    function testConstructorWithInvalidTreeDepth(uint8 actualTreeDepth) public {
+        // Setup
+        uint128 preRootTimestamp = uint128(block.timestamp);
+        vm.assume(!SemaphoreTreeDepthValidator.validate(actualTreeDepth));
+        vm.expectRevert(abi.encodeWithSignature("UnsupportedTreeDepth(uint8)", actualTreeDepth));
+
+        new OpWorldID(actualTreeDepth, preRoot, preRootTimestamp);
+    }
 
     function setUp() public override {
         /// @notice CrossDomainOwnable3 setup

--- a/test/OpWorldID.t.sol
+++ b/test/OpWorldID.t.sol
@@ -175,4 +175,16 @@ contract OpWorldIDTest is Messenger_Initializer {
         vm.expectRevert(OpWorldID.ExpiredRoot.selector);
         id.checkValidRoot(newRoot);
     }
+
+    /// @notice Checks that it is possible to get the tree depth the contract was initialized with.
+    function testCanGetTreeDepth(uint8 actualTreeDepth) public {
+        // Setup
+        vm.assume(SemaphoreTreeDepthValidator.validate(actualTreeDepth));
+        uint128 preRootTimestamp = uint128(block.timestamp);
+
+        id = new OpWorldID(actualTreeDepth, preRoot, preRootTimestamp);
+
+        // Test
+        assert(id.getTreeDepth() == actualTreeDepth);
+    }
 }

--- a/test/PolygonWorldID.t.sol
+++ b/test/PolygonWorldID.t.sol
@@ -68,6 +68,15 @@ contract PolygonWorldIDTest is PRBTest, StdCheats {
         vm.label(address(id), "PolygonWorldID");
     }
 
-    /// pending unit tests, hard to test internal functions that depend on Polygon State Bridge functionality
-    /// no straightforward way to vm.prank as the Polygon State Bridge (fxChildTunnel)
+    /// @notice Checks that it is possible to get the tree depth the contract was initialized with.
+    function testCanGetTreeDepth(uint8 actualTreeDepth) public {
+        // Setup
+        vm.assume(SemaphoreTreeDepthValidator.validate(actualTreeDepth));
+        uint128 preRootTimestamp = uint128(block.timestamp);
+
+        id = new PolygonWorldID(actualTreeDepth, fxChild, preRoot, preRootTimestamp, stateBridgeAddress);
+
+        // Test
+        assert(id.getTreeDepth() == actualTreeDepth);
+    }
 }

--- a/test/PolygonWorldID.t.sol
+++ b/test/PolygonWorldID.t.sol
@@ -17,6 +17,9 @@ contract PolygonWorldIDTest is PRBTest, StdCheats {
     /// @notice The PolygonWorldID contract
     PolygonWorldID internal id;
 
+    /// @notice MarkleTree depth
+    uint8 internal treeDepth = 16;
+
     /// @notice The root of the merkle tree before the first update
     uint256 public preRoot = 0x18f43331537ee2af2e3d758d50f72106467c6eea50371dd528d57eb2b856d238;
 
@@ -47,7 +50,7 @@ contract PolygonWorldIDTest is PRBTest, StdCheats {
 
         /// @notice Initialize the PolygonWorldID contract
         vm.prank(alice);
-        id = new PolygonWorldID(fxChild, preRoot, preRootTimestamp, stateBridgeAddress);
+        id = new PolygonWorldID(treeDepth, fxChild, preRoot, preRootTimestamp, stateBridgeAddress);
 
         /// @dev label important addresses
         vm.label(address(this), "Sender");

--- a/test/PolygonWorldID.t.sol
+++ b/test/PolygonWorldID.t.sol
@@ -2,6 +2,7 @@
 pragma solidity >=0.8.15;
 
 import {PolygonWorldID} from "../src/PolygonWorldID.sol";
+import {SemaphoreTreeDepthValidator} from "../src/utils/SemaphoreTreeDepthValidator.sol";
 import {PRBTest} from "@prb/test/PRBTest.sol";
 import {StdCheats} from "forge-std/StdCheats.sol";
 
@@ -39,6 +40,16 @@ contract PolygonWorldIDTest is PRBTest, StdCheats {
     address public stateBridgeAddress = address(0x3333333);
 
     bytes public data;
+
+    function testConstructorWithInvalidTreeDepth(uint8 actualTreeDepth) public {
+        // Setup
+        uint128 preRootTimestamp = uint128(block.timestamp);
+        vm.assume(!SemaphoreTreeDepthValidator.validate(actualTreeDepth));
+        vm.expectRevert(abi.encodeWithSignature("UnsupportedTreeDepth(uint8)", actualTreeDepth));
+
+        new PolygonWorldID(actualTreeDepth, fxChild, preRoot, preRootTimestamp, stateBridgeAddress);
+    }
+
 
     function setUp() public {
         /// @notice The timestamp of the root of the merkle tree before the first update


### PR DESCRIPTION
Changes
- Use Worldcoin Semaphore fork
- Take tree depth as a param
- Update Semaphore's `verifyProof` usage
- Fix tests