### PR TITLE
Add `verifyCompressedProof()` to `IWorldID`

### DIFF
--- a/src/interfaces/IWorldID.sol
+++ b/src/interfaces/IWorldID.sol
@@ -25,4 +25,12 @@ interface IWorldID {
         uint256 externalNullifierHash,
         uint256[8] calldata proof
     ) external;
+
+    function verifyCompressedProof(
+        uint256 root,
+        uint256 signalHash,
+        uint256 nullifierHash,
+        uint256 externalNullifierHash,
+        uint256[4] calldata compressedProof
+    ) external view;
 }


### PR DESCRIPTION
This PR updates the `IWorldID` interface to include the newly added `verifyCompressedProof()` function.
