### PR TITLE
Resolution of unused and depricated submodule. From HackerOne report.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -14,10 +14,6 @@
 	path = lib/openzeppelin-contracts-upgradeable
 	url = https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable
 	branch = v4.8.1
-[submodule "lib/contracts"]
-	path = lib/contracts
-	url = https://github.com/fx-portal/contracts
-	branch = v1.0.5
 [submodule "lib/solmate"]
 	path = lib/solmate
 	url = https://github.com/transmissions11/solmate

--- a/foundry.toml
+++ b/foundry.toml
@@ -31,7 +31,6 @@ remappings = [
   "openzeppelin-contracts/=lib/openzeppelin-contracts/contracts/",
   "@openzeppelin/contracts-upgradeable/=lib/openzeppelin-contracts-upgradeable/contracts/",
   "@openzeppelin/contracts/=lib/openzeppelin-contracts/contracts/",
-  "fx-portal/contracts/=lib/contracts/contracts/",
 ]
 
 # Make formatting consistent.


### PR DESCRIPTION
Submodule has been depricated fully by FxPortal. Removing the full reference to reduce attack surface risk presented via HackerOne report.

https://linear.app/worldcoin/issue/SEC-1793/h1-critical-remote-code-execution-via-git-submodule-hijacking-in